### PR TITLE
Improve mobile layout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -503,21 +503,21 @@ const AppLogicContainer: React.FC<AppLogicContainerProps> = ({
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-darkBg text-gray-900 dark:text-darkText transition-colors duration-300 flex flex-col">
+    <div className="min-h-screen bg-gray-100 dark:bg-darkBg text-gray-900 dark:text-darkText transition-colors duration-300 flex flex-col text-sm sm:text-base">
       <NotificationContainer notifications={notifications} onRemoveNotification={removeNotification} />
       <Header currentGroupId={currentGroupId} allGroups={userVisibleGroups} darkMode={darkMode} onSetCurrentGroupId={setCurrentGroupId} onInitiateCreateGroup={initiateCreateGroupProcess} onSetDarkMode={setDarkMode} onShowGlobalSettingsModal={() => setShowGlobalSettingsModal(true)} appMode="offline" setAppMode={setAppMode} onShowSetUserNameModal={() => setShowSetUserNameModal(true)} currentUser={currentUser} />
 
     {shouldShowContent ? (
       <>
         {currentGroup && (<div className="hidden md:block sticky top-[80px] z-30 bg-white dark:bg-darkSurface shadow-sm"><nav className="container mx-auto"><TabNavigation activeTab={activeTab} onSetTab={setActiveTab} isMobile={false} /></nav></div>)}
-        <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow">
+        <main className="container mx-auto px-2 sm:px-4 md:px-6 lg:px-8 py-6 flex-grow">
           {currentGroup && (<div className="mb-6 flex flex-col sm:flex-row items-start sm:items-center justify-between"><div className="flex items-center space-x-3 mb-3 sm:mb-0">{currentGroup.name.includes("Apartment") ? <BuildingOfficeIcon className="w-8 h-8 text-primary-500 dark:text-primary-400"/> : <UsersIcon className="w-8 h-8 text-primary-500 dark:text-primary-400"/>}<h2 className="text-2xl font-semibold text-gray-700 dark:text-darkText">Group: {currentGroup.name}</h2></div></div>)}
           {renderActiveTabView()}
         </main>
         {currentGroup && (<div className="md:hidden"><TabNavigation activeTab={activeTab} onSetTab={setActiveTab} isMobile={true} /></div>)}
       </>
      ) : ( 
-        <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow flex flex-col items-center justify-center">
+        <main className="container mx-auto px-2 sm:px-4 md:px-6 lg:px-8 py-6 flex-grow flex flex-col items-center justify-center">
             <ExclamationTriangleIcon className="w-12 h-12 text-yellow-500 mb-4" /> <h2 className="text-xl font-semibold text-gray-800 dark:text-white mb-2">Application Error</h2>
             <p className="text-gray-600 dark:text-darkMuted"> SettleUp is not configured correctly. Please contact support. </p>
         </main>
@@ -600,7 +600,7 @@ const AppContent: React.FC<AppContentProps> = ({ initialAppModeFromIndex }) => {
 
   if (!appConfig.enableOfflineMode) { 
     return (
-        <div className="min-h-screen bg-gray-100 dark:bg-darkBg flex flex-col items-center justify-center p-6 text-center">
+        <div className="min-h-screen bg-gray-100 dark:bg-darkBg flex flex-col items-center justify-center p-4 sm:p-6 text-center">
             <NotificationContainer notifications={notifications} onRemoveNotification={removeNotification} />
             <ExclamationTriangleIcon className="w-16 h-16 text-red-500 mb-4" />
             <h1 className="text-2xl font-semibold text-gray-800 dark:text-white mb-2">Application Configuration Error</h1>

--- a/components/BalanceSummary.tsx
+++ b/components/BalanceSummary.tsx
@@ -75,7 +75,7 @@ export const BalanceSummary: React.FC<BalanceSummaryProps> = ({
   }, [memberPaymentsList]);
 
   return (
-    <div className="bg-white dark:bg-darkSurface shadow-xl rounded-xl p-6 space-y-6">
+    <div className="bg-white dark:bg-darkSurface shadow-xl rounded-xl p-4 sm:p-6 space-y-6">
         {/* Outstanding Debts Section - Moved to top */}
         <div className="pb-6">
             <h2 className="text-xl font-semibold text-gray-800 dark:text-darkText mb-4 flex items-center">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -20,7 +20,7 @@ export const Footer: React.FC<FooterProps> = ({ currentUser, appMode }) => {
 
 
     return (
-        <footer className="text-center py-8 mt-12 border-t border-gray-200 dark:border-gray-700">
+        <footer className="text-center py-4 sm:py-8 mt-8 sm:mt-12 border-t border-gray-200 dark:border-gray-700">
             <p className="text-sm text-gray-500 dark:text-darkMuted">&copy; {new Date().getFullYear()} SettleUp. {displayMessage}
             </p>
         </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -53,7 +53,7 @@ export const Header: React.FC<HeaderProps> = ({
 
     return (
         <header className="bg-primary-600 dark:bg-gray-800 text-white shadow-md sticky top-0 z-40">
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8 h-20 flex justify-between items-center">
+            <div className="container mx-auto px-3 sm:px-6 lg:px-8 h-16 sm:h-20 flex justify-between items-center">
                 <div className="flex items-center">
                     <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">SettleUp</h1>
                     {/* Mode display text removed from here */}

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -18,7 +18,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onSelectMode }) => {
   const numberOfCards = showLocalCard ? 1 : 0;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-600 to-primary-800 dark:from-gray-800 dark:to-gray-900 flex flex-col justify-center items-center p-6 text-white antialiased overflow-hidden">
+    <div className="min-h-screen bg-gradient-to-br from-primary-600 to-primary-800 dark:from-gray-800 dark:to-gray-900 flex flex-col justify-center items-center p-4 sm:p-6 text-white antialiased overflow-hidden">
       <div className="text-center mb-10 sm:mb-16">
         <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold mb-4 tracking-tight animate-fade-in-item" style={{ animationDelay: '0.1s' }}>
           SettleUp

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -44,7 +44,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, size = 
             <XMarkIcon className="w-6 h-6" />
           </button>
         </div>
-        <div className="p-5 sm:p-6">{children}</div>
+        <div className="p-4 sm:p-6">{children}</div>
       </div>
     </div>
   );

--- a/components/SpendAnalyser.tsx
+++ b/components/SpendAnalyser.tsx
@@ -65,7 +65,7 @@ const SpendAnalyser: React.FC<SpendAnalyserProps> = ({ expenses, members, users,
   const listContainerHeight = "max-h-60"; // Consistent height for scrollable lists
 
   return (
-    <div className="bg-white dark:bg-darkSurface shadow-xl rounded-xl p-6 space-y-8 animate-fade-in-item">
+    <div className="bg-white dark:bg-darkSurface shadow-xl rounded-xl p-4 sm:p-6 space-y-8 animate-fade-in-item">
       <div className="pb-4 border-b border-gray-200 dark:border-gray-600">
         <h2 className="text-2xl font-semibold text-gray-800 dark:text-darkText">Spend Analyser</h2>
         {/* "Close Analyser" button removed */}

--- a/components/TabNavigation.tsx
+++ b/components/TabNavigation.tsx
@@ -20,7 +20,7 @@ const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onSetTab, isMo
   if (isMobile) {
     return (
       <nav className="fixed bottom-0 left-0 right-0 bg-white dark:bg-darkSurface border-t border-gray-200 dark:border-gray-700 shadow-top z-30">
-        <div className="flex justify-around items-center h-16">
+        <div className="flex justify-around items-center h-12">
           {tabConfig.map((tab) => {
             const isActive = activeTab === tab.id;
             const IconComponent = tab.icon;

--- a/components/views/MembersView.tsx
+++ b/components/views/MembersView.tsx
@@ -24,7 +24,7 @@ const MembersView: React.FC<MembersViewProps> = ({ group, onShowGroupSettingsMod
 
 
   return (
-    <div className="bg-white dark:bg-darkSurface shadow-xl rounded-xl p-6">
+    <div className="bg-white dark:bg-darkSurface shadow-xl rounded-xl p-4 sm:p-6">
       <div className="flex justify-between items-center mb-6 pb-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-xl font-semibold text-gray-800 dark:text-darkText">
           Group Members ({group.members.length})


### PR DESCRIPTION
## Summary
- tighten up header/footer spacing on mobile
- shrink bottom navigation height
- reduce padding on modals, landing page and analyzer sections
- make main content padding responsive

## Testing
- `npm run dev` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb2fe2440832d9549adb7db04d2bc