### PR TITLE
Fix dark mode icon visibility

### DIFF
--- a/components/BalanceSummary.tsx
+++ b/components/BalanceSummary.tsx
@@ -211,7 +211,7 @@ export const BalanceSummary: React.FC<BalanceSummaryProps> = ({
                 {lowestPayerAmongPayers && topPayer?.userId !== lowestPayerAmongPayers.userId && ( 
                     <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
                         <span className="flex items-center text-gray-700 dark:text-darkText">
-                           <BanknotesIcon className="w-5 h-5 mr-2 text-gray-400 dark:text-gray-500 opacity-70" /> Lowest Payer (Among Payers):
+                           <BanknotesIcon className="w-5 h-5 mr-2 text-gray-400 dark:text-gray-400 opacity-70" /> Lowest Payer (Among Payers):
                         </span>
                         <strong className="text-gray-800 dark:text-white">{lowestPayerAmongPayers.name.split(' ')[0]} ({formatCurrency(lowestPayerAmongPayers.amount, selectedCurrency)})</strong>
                     </div>

--- a/components/ExpenseItem.tsx
+++ b/components/ExpenseItem.tsx
@@ -80,7 +80,7 @@ export const ExpenseItem: React.FC<ExpenseItemProps> = ({ expense, groupMembers,
           </div>
           <div className="mb-4">
             <p className="text-xs font-medium text-gray-500 dark:text-darkMuted mb-1.5 flex items-center">
-                <ShareIcon className="w-4 h-4 mr-1.5 text-gray-400 dark:text-gray-500" />
+                <ShareIcon className="w-4 h-4 mr-1.5 text-gray-400 dark:text-gray-300" />
                 Split {expense.splitType.toLowerCase().replace('_', ' ')} among:
             </p>
             <div className="flex flex-wrap gap-1.5">

--- a/components/ExpenseTableRow.tsx
+++ b/components/ExpenseTableRow.tsx
@@ -88,7 +88,7 @@ const ExpenseTableRow: React.FC<ExpenseTableRowProps> = ({
               <TrashIcon className="w-4 h-4" />
             </button>
           </div>
-        ) : <span className="text-xs text-gray-400 dark:text-gray-500">N/A</span>}
+        ) : <span className="text-xs text-gray-400 dark:text-gray-400">N/A</span>}
       </td>
     </tr>
   );

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -38,7 +38,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, size = 
           <h2 id="modal-title" className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-darkText">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600"
+            className="text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-gray-200 transition-colors p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600"
             aria-label="Close modal"
           >
             <XMarkIcon className="w-6 h-6" />

--- a/components/NoGroupsView.tsx
+++ b/components/NoGroupsView.tsx
@@ -38,7 +38,7 @@ const NoGroupsView: React.FC<NoGroupsViewProps> = ({ onInitiateCreateGroup, appM
                  // This part should ideally not be reached if App.tsx handles the error state correctly.
                  // It's a defensive message.
                  <>
-                    <BuildingOfficeIcon className="w-24 h-24 text-gray-400 dark:text-gray-500 mb-6"/>
+                    <BuildingOfficeIcon className="w-24 h-24 text-gray-400 dark:text-gray-400 mb-6"/>
                     <h1 className="text-3xl font-bold mb-3 dark:text-white">
                         Application Not Available
                     </h1>

--- a/components/TabNavigation.tsx
+++ b/components/TabNavigation.tsx
@@ -65,7 +65,7 @@ const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onSetTab, isMo
                         }`}
             aria-current={isActive ? 'page' : undefined}
           >
-            <IconComponent className={`w-5 h-5 mr-2 ${isActive ? 'text-primary-500 dark:text-primary-400' : 'text-gray-400 dark:text-gray-500 group-hover:text-gray-500 dark:group-hover:text-gray-400'}`} />
+            <IconComponent className={`w-5 h-5 mr-2 ${isActive ? 'text-primary-500 dark:text-primary-400' : 'text-gray-400 dark:text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300'}`} />
             {tab.label}
           </button>
         );

--- a/components/modals/AddMultipleBillsModal.tsx
+++ b/components/modals/AddMultipleBillsModal.tsx
@@ -96,7 +96,7 @@ const AddMultipleBillsModal: React.FC<AddMultipleBillsModalProps> = ({
               key={entry.id} 
               className="flex flex-nowrap items-center gap-1 sm:gap-1.5 p-2 border border-gray-200 dark:border-gray-600 rounded-lg shadow-sm bg-gray-50 dark:bg-gray-700/30 min-w-[700px] sm:min-w-0" // min-w for horizontal scroll content
             >
-              <span className="flex-shrink-0 text-xs font-semibold text-gray-400 dark:text-gray-500 w-7 sm:w-8 text-center">#{index + 1}</span>
+              <span className="flex-shrink-0 text-xs font-semibold text-gray-400 dark:text-gray-400 w-7 sm:w-8 text-center">#{index + 1}</span>
               <input
                 type="date"
                 value={entry.date} // Value is YYYY-MM-DD

--- a/components/views/BillsView.tsx
+++ b/components/views/BillsView.tsx
@@ -137,7 +137,7 @@ const BillsView: React.FC<BillsViewProps> = ({
         )
       ) : (
         <div className="bg-white dark:bg-darkSurface shadow-lg rounded-xl p-10 text-center">
-          <CalendarDaysIcon className="w-16 h-16 text-gray-400 dark:text-gray-500 mx-auto mb-4" />
+          <CalendarDaysIcon className="w-16 h-16 text-gray-400 dark:text-gray-400 mx-auto mb-4" />
           <h3 className="text-xl font-semibold text-gray-700 dark:text-darkText mb-2">No Bills Yet</h3>
           <p className="text-gray-500 dark:text-darkMuted mb-6">
             Get started by adding the first bill for this group.

--- a/components/views/MembersView.tsx
+++ b/components/views/MembersView.tsx
@@ -69,7 +69,7 @@ const MembersView: React.FC<MembersViewProps> = ({ group, onShowGroupSettingsMod
                     className="w-10 h-10 rounded-full object-cover mr-3 border-2 border-gray-200 dark:border-gray-600"
                     />
                 ) : (
-                    <DefaultUserIcon className="w-10 h-10 text-gray-400 dark:text-gray-500 mr-3 p-1 bg-gray-200 dark:bg-gray-600 rounded-full" />
+                    <DefaultUserIcon className="w-10 h-10 text-gray-400 dark:text-gray-300 mr-3 p-1 bg-gray-200 dark:bg-gray-600 rounded-full" />
                 )}
                 <div>
                     <p className="font-medium text-gray-800 dark:text-darkText">


### PR DESCRIPTION
## Summary
- lighten dark mode icons and text colors so they remain visible

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685cb4b91aa4832d981dda50f1f6d0d1