### PR TITLE
Improve dark mode handling

### DIFF
--- a/components/NotificationSystem.tsx
+++ b/components/NotificationSystem.tsx
@@ -33,7 +33,11 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ notification, onRem
         {icon}
         <p className="ml-3 text-sm font-medium">{notification.message}</p>
       </div>
-      <button onClick={() => onRemove(notification.id)} className="ml-auto -mx-1.5 -my-1.5 p-1.5 rounded-lg inline-flex h-8 w-8 hover:bg-white/20 focus:ring-2 focus:ring-white/30" aria-label="Dismiss notification">
+      <button
+        onClick={() => onRemove(notification.id)}
+        className="ml-auto -mx-1.5 -my-1.5 p-1.5 rounded-lg inline-flex h-8 w-8 hover:bg-white/20 dark:hover:bg-gray-700/40 focus:ring-2 focus:ring-white/30 dark:focus:ring-gray-500"
+        aria-label="Dismiss notification"
+      >
         <CloseIcon className="w-5 h-5" />
       </button>
     </div>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SettleUp - Professional Bill Splitting</title>
 
+    <script>
+      try {
+        const settings = JSON.parse(localStorage.getItem('settleUpAppGeneralSettings_v4_mode') || '{}');
+        if (settings.darkMode) document.documentElement.classList.add('dark');
+      } catch (e) {
+        console.error('Failed to apply saved theme', e);
+      }
+    </script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {


### PR DESCRIPTION
## Summary
- apply user's saved theme immediately on page load
- tweak notification close button hover/focus styles for dark mode

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685cb907153c832d93ec336050a09e7a